### PR TITLE
refactor(claude): review-skillをcontext: forkパターンに書き換え

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,8 @@
 {
   "cleanupPeriodDays": 30,
+  "env": {
+    "DISABLE_AUTOUPDATER": "1"
+  },
   "includeCoAuthoredBy": false,
   "permissions": {
     "allow": [
@@ -75,7 +78,6 @@
     ],
     "defaultMode": "default"
   },
-  "model": "opus",
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/skills/review-skill/SKILL.md
+++ b/.claude/skills/review-skill/SKILL.md
@@ -19,7 +19,7 @@ You are a Claude Code skill reviewer.
 3. Review the skill against the official documentation. Check:
    - Frontmatter: Are `name` and `description` present and well-written?
    - Description quality: Is it concise (1-2 sentences)? Does it include both what the skill does and when to use it?
-   - No extra frontmatter fields beyond name/description (and optional argument-hint, compatibility)
+   - Frontmatter fields: Only officially documented fields are used (`name`, `description`, `argument-hint`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `model`, `context`, `agent`, `hooks`)
    - Body: Is it under 500 lines? Is progressive disclosure used appropriately?
    - Resources: Are bundled scripts/references/assets organized correctly?
    - No unnecessary files (README.md, CHANGELOG.md, etc.)

--- a/.claude/skills/review-skill/SKILL.md
+++ b/.claude/skills/review-skill/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: review-skill
+description: Review a Claude Code skill against official best practices. Use when the user asks to review, lint, or check a skill quality.
+argument-hint: [path/to/SKILL.md]
+context: fork
+allowed-tools: Read, Glob, Bash(ls *), WebFetch
+---
+
+You are a Claude Code skill reviewer.
+
+## Workflow
+
+1. Fetch the latest official skill documentation:
+   - Use WebFetch on https://code.claude.com/docs/en/skills
+   - Extract all best practices, required fields, and recommendations
+
+2. Read the target skill file: $ARGUMENTS
+
+3. Review the skill against the official documentation. Check:
+   - Frontmatter: Are `name` and `description` present and well-written?
+   - Description quality: Is it concise (1-2 sentences)? Does it include both what the skill does and when to use it?
+   - No extra frontmatter fields beyond name/description (and optional argument-hint, compatibility)
+   - Body: Is it under 500 lines? Is progressive disclosure used appropriately?
+   - Resources: Are bundled scripts/references/assets organized correctly?
+   - No unnecessary files (README.md, CHANGELOG.md, etc.)
+
+4. Output a structured review:
+   - Summary (1-2 lines)
+   - Checklist table (item, status, notes)
+   - Specific improvement suggestions with diff examples where applicable
+
+Output the review in the same language as the user request.


### PR DESCRIPTION
## 概要

review-skillを公式ドキュメント推奨の`context: fork`パターンに書き換え、スキル本文のレビューチェックリストを公式仕様に準拠させた。

## 変更内容

### review-skill (`.claude/skills/review-skill/SKILL.md`)
- `context: fork` + `allowed-tools` による宣言的サブエージェント委譲に変更
- `argument-hint` を角括弧形式に修正（公式ドキュメント準拠）
- スキル本文からTask tool起動のメタ指示を除去し、レビュータスクそのものに集中する構成に
- frontmatterフィールドのチェックリストを公式ドキュメント準拠の全10フィールドに修正（`context`, `allowed-tools`等の有効フィールドを誤検知する問題を解消）

### settings.json
- 不要な `model` 指定を削除
- `DISABLE_AUTOUPDATER` 環境変数を追加

## テスト計画

- [x] `/review-skill` でスキルが正常に発火することを確認
- [x] サブエージェントがWebFetchで公式ドキュメントを取得しレビューを実行することを確認