### PR TITLE
chore: mo.nvim追加とagent自律実行設定の強化

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -80,7 +80,7 @@
       "Bash(sudo:*)",
       "Bash(yum install:*)"
     ],
-    "defaultMode": "default"
+    "defaultMode": "auto"
   },
   "enableAllProjectMcpServers": false,
   "hooks": {
@@ -232,6 +232,8 @@
   },
   "outputStyle": "Explanatory",
   "language": "Japanese",
+  "effortLevel": "xhigh",
   "plansDirectory": ".plans",
-  "prefersReducedMotion": false
+  "prefersReducedMotion": false,
+  "skipAutoPermissionPrompt": true
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -212,7 +212,8 @@
     "notion-workflow@castingone-claude-plugins": true,
     "lua-lsp@claude-plugins-official": true,
     "backend-workflow@castingone-claude-plugins": true,
-    "git@castingone-claude-plugins": true
+    "git@castingone-claude-plugins": true,
+    "release-workflow@castingone-claude-plugins": true
   },
   "extraKnownMarketplaces": {
     "pokutuna-plugins": {

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -7,7 +7,7 @@ approval_policy = "never"
 # 何の設定か分からないので保留
 # file_opener = "cursor" # or vscode
 notify = ["bash","-lc","afplay /System/Library/Sounds/Ping.aiff"]
-model_reasoning_effort = "medium"
+model_reasoning_effort = "high"
 personality = "pragmatic"
 service_tier = "fast"
 

--- a/.config/nvim/lua/plugins/sandbox.lua
+++ b/.config/nvim/lua/plugins/sandbox.lua
@@ -31,4 +31,15 @@ return {
       })
     end,
   },
+  {
+    "okm321/mo.nvim",
+    ft = { "markdown" },
+    cmd = { "MoAdd", "MoAddDir", "MoPick", "MoStatus", "MoWatch", "MoRestart", "MoShutdown", "MoClear" },
+    opts = {},
+    keys = {
+      { "<leader>mo", "<cmd>MoAdd<cr>", desc = "Add to mo" },
+      { "<leader>mp", "<cmd>MoPick<cr>", desc = "Pick files for mo" },
+      { "<leader>ms", "<cmd>MoStatus<cr>", desc = "mo status" },
+    },
+  },
 }


### PR DESCRIPTION
## Summary

- mo.nvim ([okm321/mo.nvim](https://github.com/okm321/mo.nvim)) をsandboxに追加し、Neovimからmo Markdownビューアーを操作できるようにする（`<leader>mo/mp/ms` にキーマップ割当）
- Claude Codeの `defaultMode` を `auto` に変更し、`effortLevel=xhigh` / `skipAutoPermissionPrompt=true` を追加して自律実行と推論レベルを強化
- `release-workflow@castingone-claude-plugins` を有効化し、後方互換性チェック等のリリース系スキルを利用可能に
- Codex CLIの `model_reasoning_effort` を `high` に引き上げ、Claude側と推論レベルを揃える

## Test plan

- [ ] nvim 再起動後に `:Lazy sync` で mo.nvim が導入されることを確認
- [ ] markdown ファイルで `:MoAdd` / `:MoPick` / `:MoStatus` が動作することを確認
- [ ] Claude Code 起動時に auto モードで立ち上がり、権限プロンプトがオートスキップされることを確認
- [ ] release-workflow スキル（`/release-workflow:backward-compat-check` 等）が補完候補に出ることを確認