### PR TITLE
chore(claude): slack有効化とUI/通知設定の更新

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -203,7 +203,8 @@
     "lua-lsp@claude-plugins-official": true,
     "backend-workflow@castingone-claude-plugins": true,
     "git@castingone-claude-plugins": true,
-    "release-workflow@castingone-claude-plugins": true
+    "release-workflow@castingone-claude-plugins": true,
+    "slack@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "pokutuna-plugins": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -84,8 +84,7 @@
   },
   "enableAllProjectMcpServers": false,
   "hooks": {
-    "PreToolUse": [
-    ],
+    "PreToolUse": [],
     "PostToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit",
@@ -223,8 +222,13 @@
   },
   "outputStyle": "Explanatory",
   "language": "Japanese",
+  "effortLevel": "xhigh",
   "plansDirectory": ".plans",
   "prefersReducedMotion": false,
+  "theme": "dark-daltonized",
+  "terminalProgressBarEnabled": false,
+  "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "effortLevel": "high"
+  "tui": "fullscreen",
+  "viewMode": "focus"
 }

--- a/.gitconfig
+++ b/.gitconfig
@@ -48,3 +48,4 @@
   copy = .envrc
   copy = compose.override.yaml
   copy = .env.local
+  copy = .env.default.local


### PR DESCRIPTION
## Summary

- Claude Codeのslackプラグインを有効化し、Slack関連スキルを利用可能にする
- UI/通知設定 (theme/tui/viewMode/agentPushNotifEnabled/terminalProgressBarEnabled) を追加し、effortLevelをxhighへ引き上げ
- worktree作成時のcopy対象に.env.default.localを追加

## Commits

| Commit | 内容 |
|---|---|
| chore(claude): slackプラグインを有効化 | Slack連携プラグインの有効化 |
| chore(claude): UI/通知設定とeffortLevelを更新 | UI/通知関連の設定追加とeffortLevel調整 |
| chore(git): worktreeのcopy対象に.env.default.localを追加 | 新規worktreeで環境変数デフォルト値を即時利用 |

## Test plan

- [x] `claude` 起動時にfullscreen TUI / focus viewMode / dark-daltonized theme が反映されることを確認
- [x] `/slack:*` 系スキルがロードされることを確認
- [x] 新規worktree作成時に.env.default.localがコピーされることを確認