### PR TITLE
fix(sidekick): Claude Code の focus event leak を抑止

### DIFF
--- a/.config/nvim/lua/plugins/ai.lua
+++ b/.config/nvim/lua/plugins/ai.lua
@@ -5,7 +5,7 @@ return {
       cli = {
         mux = {
           backend = "tmux",
-          enabled = false,
+          enabled = true,
         },
         win = {
           keys = {

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -50,8 +50,12 @@ if-shell "uname | grep -q Darwin" \
 if-shell 'type xsel' \
   'bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel "xsel -ip && xsel -op | xsel -ib"'
 
-# for nvim
-set-option -g focus-events on
+# focus-events は off。
+# nvim 自身は :checktime 系を使っておらず、依存プラグイン (gitsigns blame refresh,
+# image.nvim の描画停止, which-key の popup close 等) は focus 無効でも実害が無い。
+# off にすることで sidekick.nvim 経由 (Neovim :terminal → tmux → claude) の
+# spurious focus event leak (anthropics/claude-code#10375) も同時に抑止する。
+set-option -g focus-events off
 
 # window name
 bind c new-window -n "window"


### PR DESCRIPTION
## Summary

sidekick.nvim 経由で Claude Code を使うときに、マウス選択や `/copy` のたびに `\e[I` `\e[O` (focus reporting シーケンス) が入力欄に流入する問題を抑止する。

`Neovim :terminal (libvterm) → tmux → claude` のレイヤで、libvterm が発火する spurious な focus event が tmux 経由で Claude Code に届き、Claude Code 側の入力ハンドラがこれを filter していない ([anthropics/claude-code#10375](https://github.com/anthropics/claude-code/issues/10375)) ことが原因。

## 変更内容

- **`.tmux.conf`**: `focus-events` を `on` → `off` に変更。nvim 自身は `:checktime` 系を使っておらず、依存プラグイン (gitsigns blame refresh, image.nvim の描画停止, which-key の popup close, overseer の通知出し分け, codediff auto-refresh) も focus 無効で実害なし。
- **`.config/nvim/lua/plugins/ai.lua`**: sidekick.nvim の `cli.mux.enabled` を `true` に変更。coding agent session を tmux で永続化し、nvim 再起動後も `<leader>ac` で同じ会話に attach できる。`focus-events off` のメイン tmux server に session が乗るので leak も同時に消える。

## Test plan

- [ ] `tmux source-file ~/.tmux.conf` または `prefix r` で reload し `tmux show-options -g focus-events` が `off` を返す
- [ ] nvim 再起動後 `<leader>ac` で Claude Code を起動
- [ ] マウスドラッグで会話を選択 → 入力欄に `[I` `[O` が出ない
- [ ] `/copy` 実行 → 入力欄に leak しない
- [ ] Claude Code fullscreen のマウス自動コピー (ドラッグでクリップボードへ) は通常通り動作
- [ ] `tmux ls` で sidekick の session が見える、再 `<leader>ac` で同じ session に attach する
- [ ] gitsigns の blame、image.nvim の描画など focus-events 依存プラグインで実害が出ないことを 1〜2 日体感で確認

## Rollback

`#10375` が修正されたら以下で巻き戻し:
- `.tmux.conf`: `focus-events on` に戻す
- `ai.lua`: 必要なら `mux.enabled = false` も検討