### PR TITLE
chore(gitignore): .claude/rules/ を追跡対象に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ _build.json
 !.claude/scripts/
 !.claude/skills/
 !.claude/plugins/
+!.claude/rules/
 .claude/plugins/cache/
 .claude/plugins/marketplaces/
 .claude/plugins/blocklist.json


### PR DESCRIPTION
## Summary

`.claude/rules/` 配下のファイルを git で管理できるよう、`.gitignore` の負パターンに追加する。

`.claude/` 配下は基本的に ignore されているが、ユーザー管理対象 (`.claude/scripts/`, `.claude/skills/`, `.claude/plugins/`) は明示的に許可している。`.claude/rules/` も同じ運用に倣い、これから格納予定の rule 定義ファイルを追跡対象にする。

## 変更内容

- `.gitignore`: `!.claude/scripts/`, `!.claude/skills/`, `!.claude/plugins/` の並びに `!.claude/rules/` を追加（1 行追加）

## Test plan

- [ ] `.claude/rules/example.md` のようなテストファイルを置いて `git status` に出ることを確認
- [ ] 既存の `.claude/plugins/cache/` 等の deeper ignore が引き続き機能することを確認 (`!.claude/rules/` が他の負パターンに干渉しない)