### PR TITLE
chore: Claude Code 権限の絞り込みと tmux pane インジケータ追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -66,7 +66,6 @@
       "Bash(gh workflow disable:*)",
       "Bash(gh workflow enable:*)",
       "Bash(gh workflow run:*)",
-      "Bash(git checkout:*)",
       "Bash(git config:*)",
       "Bash(git rebase:*)",
       "Bash(git reset --hard:*)",

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -80,6 +80,8 @@ set -g status-position top
 
 # paneの罫線を太くする
 set -g pane-border-lines heavy
+# アクティブ罫線にカラー＋矢印インジケータを表示
+set -g pane-border-indicators both
 
 # キーストロークのディレイを減らす
 set -sg escape-time 1


### PR DESCRIPTION
## Summary
- Claude Code の `git checkout:*` auto allow を外し、ブランチ切り替えは明示確認に戻す
- tmux で `pane-border-indicators both` を有効化し、アクティブ pane を視覚的に判別しやすくする

## Test plan
- [ ] tmux を再読込（`prefix + r` 等）し、アクティブ pane に矢印インジケータが表示されることを確認
- [ ] Claude Code を再起動し、`git checkout` 系コマンドで permission prompt が出ることを確認